### PR TITLE
Restore emitted events after socket.destroy

### DIFF
--- a/lib/proxywrap.js
+++ b/lib/proxywrap.js
@@ -125,7 +125,8 @@ exports.proxy = function(iface, options) {
 				if (header.length >= 5 && header.substr(0, 5) != 'PROXY') {
 					protocolError = true;
 					if (options.strict) {
-						return socket.destroy('PROXY protocol error');
+						socket.destroy('PROXY protocol error');
+						return restore();
 					}
 				}
 


### PR DESCRIPTION
Internally `socket.destroy` emits an `error` event, but as `socket.emit` is being proxied and never gets restored, the listeners of `error` event will never get a chance to handle it.
