### PR TITLE
Fix connection handling for non-proxy connection when in non-strict mode

### DIFF
--- a/lib/proxywrap.js
+++ b/lib/proxywrap.js
@@ -146,8 +146,10 @@ exports.proxy = function(iface, options) {
 					header = header.substr(0, crlf);
 
 					// Check if header is valid
-					if( ! ProxyProtocolRegexp.test( header ) ) {
-						return destroy( "PROXY protocol error" );
+					if (options.strict) {
+						if( ! ProxyProtocolRegexp.test( header ) ) {
+							return destroy( "PROXY protocol error" );
+						}
 					}
 
 					var hlen = header.length;


### PR DESCRIPTION
fixes situation where if using non-strict mode and a non proxy protocol connection comes in everything blows up. This has probably been broken since d3599dca91267b8e9ad6beba1f30134f7f9e3958
