### PR TITLE
dirty fix for node 4.0

### DIFF
--- a/lib/proxywrap.js
+++ b/lib/proxywrap.js
@@ -1,3 +1,4 @@
+var node400 = process.version ===  'v4.0.0';
 /*
  * node-proxywrap
  *
@@ -128,7 +129,6 @@ exports.proxy = function(iface, options) {
 		this.removeAllListeners('connection');
 		this.addListener('connection', connectionListener);
 
-
 		// add the old connection listeners to a custom event, which we'll fire after processing the PROXY header
 		for (var i = 0; i < cl.length; i++) {
 			this.addListener('proxiedConnection', cl[i]);
@@ -209,13 +209,17 @@ exports.proxy = function(iface, options) {
 
 		function onReadable() {
 			var chunk;
-			chunk = socket.read();
+			if(node400){
+			    chunk = !socket._readableState.ended && socket.read();
+			}else{
+			    chunk = socket.read();
+			}
 
-			if(null === chunk && header.length === 0){
-					// unshifting will fire the readable event
-					socket.emit = realEmit;
-					self.emit('proxiedConnection', socket);
-					return;
+			if(!chunk && header.length === 0){
+			    // unshifting will fire the readable event
+		  	    socket.emit = realEmit;
+			    self.emit('proxiedConnection', socket);
+		  	    return;
 			}
 
 			while (null !== chunk) {


### PR DESCRIPTION
This commit should fix the issue with node V4.0.0. So it looks like calling socket.read() before returning the control to the proxied server when this socket is no longer readable causes the issue. As far as I know it only happens with 4.0 but sure it can happen in other versions.