### PR TITLE
Proxy late registered 'connection' listener

### DIFF
--- a/lib/proxywrap.js
+++ b/lib/proxywrap.js
@@ -126,6 +126,15 @@ exports.proxy = function(iface, options) {
     this.removeAllListeners('connection')
     this.addListener('connection', connectionListener)
 
+    const t = this;
+
+    this.on = (event, handler) => {
+      if(event === 'connection') {
+        return this.addListener('proxiedConnection', handler);
+      }
+      return t.addListener(event, handler);
+    }
+
     // add the old connection listeners to a custom event, which we'll fire after processing the PROXY header
     for (var i = 0; i < cl.length; i++) {
       this.addListener('proxiedConnection', cl[i])


### PR DESCRIPTION
This PR fixes a bug when socket.remoteAddress was undefined when registering `connection` listeners after `findhit-proxy` constructor was called.
Example:
```js
const server = new.createServer();
server.on('connection', (socket: Socket) => {
   // socket.remoteAddress is not defined here
});
```