### PR TITLE
Replace findhit-utils with lodash at runtime (fixes #36)

### DIFF
--- a/lib/proxywrap.js
+++ b/lib/proxywrap.js
@@ -26,7 +26,7 @@
  */
 
 var util = require('util'),
-  Util = require('findhit-util'),
+  _ = require('lodash'),
   ProxyProtocolRegexp = require('./proxy-protocol.regexp.js')
 
 //var legacy = !require('stream').Duplex;  // TODO: Support <= 0.8 streams interface
@@ -98,10 +98,10 @@ function defineSocketProperties(socket, properties, header) {
 exports.proxy = function(iface, options) {
   var exports = {}
 
-  options = Util.extend(
+  options = _.merge(
     {},
     module.exports.defaults,
-    (Util.is.Object(options) && options) || {}
+    (_.isPlainObject(options) && options) || null
   )
 
   // copy iface's exports to myself

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.12",
   "description": "Wraps node's Server interfaces to be compatible with the PROXY protocol",
   "main": "lib/proxywrap.js",
+  "files": [ "lib/**", "yarn*" ],
   "author": "Josh Dague",
   "license": "BSD",
   "contributors": [
@@ -34,12 +35,13 @@
     "url": "https://github.com/findhit/proxywrap"
   },
   "dependencies": {
-    "findhit-util": "^0.2.3"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "bluebird": "^2.5.3",
     "chai": "^1.10.0",
     "eslint": "^3.19.0",
+    "findhit-util": "^0.2.3",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2",
     "spdy": "^3.4.4"

--- a/test/proxy-protocol.regexp.test.js
+++ b/test/proxy-protocol.regexp.test.js
@@ -1,5 +1,4 @@
-var Util = require('findhit-util'),
-  ProxyProtocolRegexp = require('../lib/proxy-protocol.regexp.js'),
+var ProxyProtocolRegexp = require('../lib/proxy-protocol.regexp.js'),
   sinon = require('sinon'),
   chai = require('chai'),
   expect = chai.expect

--- a/test/proxy.protocol.v1.test.js
+++ b/test/proxy.protocol.v1.test.js
@@ -1,5 +1,4 @@
-var Util = require('findhit-util'),
-  tUtil = require('./tests.util'),
+var tUtil = require('./tests.util'),
   Promise = require('bluebird'),
   net = require('net'),
   sinon = require('sinon'),

--- a/test/specific/issue-36.test.js
+++ b/test/specific/issue-36.test.js
@@ -1,0 +1,105 @@
+/* related to issue https://github.com/findhit/proxywrap/issues/36 */
+var ProxyWrap = require('../..'),
+    net = require('net'),
+    Util = require('findhit-util'),
+    assert = require('chai').assert;
+
+
+// a (modified) copy of the original findhit-util code for option generation
+function findhitUtilOptions(options) {
+    return Util.extend(
+        {},
+        ProxyWrap.defaults,
+        (Util.is.object(options) && options) || {}
+    )
+}
+
+function proxyWrapOptions(options) {
+    return ProxyWrap.proxy(net, options).options;
+}
+
+describe('Check option default logic as compared to original findhat-util #36', function() {
+
+    it('for undefined', function() {
+        assert.deepEqual(proxyWrapOptions(), findhitUtilOptions());
+    })
+
+    it('for null', function() {
+        assert.deepEqual(proxyWrapOptions(null), findhitUtilOptions(null));
+    })
+
+    it('for empty objects', function() {
+        assert.deepEqual(proxyWrapOptions({}), findhitUtilOptions({}));
+    })
+
+    it('for plain objects', function() {
+        var o = {
+            protocol: 'TCP4',
+            proxyAddress: '10.10.10.254',
+        };
+        assert.deepEqual(proxyWrapOptions(o), findhitUtilOptions(o));
+    })
+
+    it('for plain objects, overriding default', function() {
+        var o = {
+            protocol: 'TCP4',
+            proxyAddress: '10.10.10.254',
+            strict: false,
+        };
+        assert.deepEqual(proxyWrapOptions(o), findhitUtilOptions(o));
+    })
+
+    it('for plain objects, with nesting', function() {
+        var o = {
+            protocol: 'TCP4',
+            proxyAddress: '10.10.10.254',
+            test: {
+                one: 1,
+                two: 2,
+            },
+        };
+        var po = proxyWrapOptions(o),
+            fo = findhitUtilOptions(o);
+        assert.deepEqual(po, fo);
+        assert.isObject(po.test, "ProxyWrap options extend copies object field");
+        assert.isObject(fo.test, "findhit-util extend copies object field");
+        assert.deepEqual(po.test, o.test, "ProxyWrap options extend copies nested");
+        assert.deepEqual(fo.test, o.test, "findhit-util extend copies nested");
+        assert.notStrictEqual(po.test, o.test, "ProxyWrap options extend doesn't deep copy nested objects");
+        // turns out you need Util.extend(true, target, source1, ...) for deep
+        // copy, so deep copy of options wasn't previously done, but as there
+        // aren't currently any nested options anyway, and it seems like the
+        // "right thing" to do, don't worry that it's technically introducing
+        // an incompatibility.
+        // assert.notStrictEqual(fo.test, o.test, "findhit-util extend doesn't deep copy nested objects");
+    })
+
+    it('for new Object()s', function() {
+        var o = new Object();
+        o.protocol= 'TCP4';
+        o.proxyAddress= '10.10.10.254';
+        assert.deepEqual(proxyWrapOptions(o), findhitUtilOptions(o));
+    })
+
+    it('for Object', function() {
+        var o = Object;
+        o.protocol= 'TCP4';
+        o.proxyAddress= '10.10.10.254';
+        assert.deepEqual(proxyWrapOptions(o), findhitUtilOptions(o));
+    })
+
+    it('for Arrays', function() {
+        var o = [1, 2, { protocol: 'TCP4' }];
+        assert.deepEqual(proxyWrapOptions(o), findhitUtilOptions(o));
+    })
+
+    it('for number', function() {
+        var o = 80;
+        assert.deepEqual(proxyWrapOptions(o), findhitUtilOptions(o));
+    })
+
+    it('for new Number', function() {
+        var o = new Number(80);
+        assert.deepEqual(proxyWrapOptions(o), findhitUtilOptions(o));
+    })
+})

--- a/test/tests.util.js
+++ b/test/tests.util.js
@@ -1,6 +1,6 @@
 var ProxyWrap = require('../')
 var Promise = require('bluebird')
-var Util = require('findhit-util')
+var _ = require('lodash')
 var fs = require('fs')
 
 function isSecureProtocol(protocol) {
@@ -63,10 +63,10 @@ module.exports = {
     var header, body, p = server._protocol, pc = server._protocolConstructor
 
     // Prepare options
-    options = Util.extend(
+    options = _.merge(
       {},
       module.defaults.fakeConnect,
-      (Util.is.Object(options) && options) || {}
+      (_.isPlainObject(options) && options) || null
     )
 
     // Build header

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,6 +616,11 @@ lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"


### PR DESCRIPTION
This lib is BSD, but had a runtime dependency on the GPL findhit-utils,
meaning any derivitive works need to be GPL.

findhit-util is still used as a dev dependency for testing the options
behaviour.

package.json "files" array has been added to not include the test code
in the resulting package so there's no GPL dependant code in the
resulting library.